### PR TITLE
fix: and or logic

### DIFF
--- a/examples/test_binary/main.lc
+++ b/examples/test_binary/main.lc
@@ -1,0 +1,9 @@
+
+function main() {
+  let index = 0;
+  const content = "Hello world";
+  if index >= content.length || content[index] != 'r' {
+    return;
+  }
+
+}

--- a/lib/c_backend/primitives.ml
+++ b/lib/c_backend/primitives.ml
@@ -44,6 +44,8 @@ module Bin = struct
     | BitOr -> "LC_I32_BIT_OR"
     | Xor -> "LC_I32_XOR"
     | BitAnd -> "LC_I32_BIT_AND"
+    | And -> "LC_AND"
+    | Or -> "LC_OR"
 
   let to_arithmetic_op (op: Asttypes.BinaryOp.t) =
     match op with

--- a/lib/parsing/asttypes.ml
+++ b/lib/parsing/asttypes.ml
@@ -73,6 +73,8 @@ module BinaryOp = struct
     | BitOr
     | Xor
     | BitAnd
+    | And
+    | Or
     [@@deriving show]
 
   let from_token =
@@ -94,7 +96,9 @@ module BinaryOp = struct
     | Token.T_BIT_OR -> BitOr
     | Token.T_BIT_XOR -> Xor
     | Token.T_BIT_AND -> BitAnd
-    | _ -> failwith "unreachable"
+    | Token.T_AND -> And
+    | Token.T_OR -> Or
+    | _ as t -> failwith ("unreachable: " ^ Token.token_to_string t)
 
   let to_string = function
     | Equal -> "=="
@@ -113,6 +117,8 @@ module BinaryOp = struct
     | BitOr -> "|"
     | Xor -> "^"
     | BitAnd -> "&"
+    | And -> "&&"
+    | Or -> "||"
   
 end
 

--- a/lib/typing/typecheck.ml
+++ b/lib/typing/typecheck.ml
@@ -683,6 +683,17 @@ and check_expression env expr =
         Type_context.update_node_type ctx id (TypeExpr.Ctor (Ref bool_ty, []));
       )
 
+    | BinaryOp.And
+    | BinaryOp.Or
+      -> (
+        if (not (Check_helper.is_boolean ctx left_node.value)) || (not (Check_helper.is_boolean ctx right_node.value)) then (
+          let err = Type_error.(make_error ctx loc (CannotApplyBinary (op, left_node.value, right_node.value))) in
+          raise (Type_error.Error err)
+        );
+        let bool_ty = ty_boolean env in
+        Type_context.update_node_type ctx id (TypeExpr.Ctor (Ref bool_ty, []));
+      )
+
     | _ -> (
         if not (Check_helper.type_logic_compareable ctx left_node.value right_node.value) then (
           let err = Type_error.(make_error ctx loc (CannotApplyBinary (op, left_node.value, right_node.value))) in

--- a/runtime/c/runtime.h
+++ b/runtime/c/runtime.h
@@ -147,6 +147,9 @@ static LCValue LCFalse = { { .int_val = 0 }, LC_TY_BOOL };
 #define LC_I32_BIT_OR(l, r) MK_I32((l).int_val | (r).int_val)
 #define LC_I32_BIT_AND(l, r) MK_I32((l).int_val & (r).int_val)
 
+#define LC_AND(l, r) (((l).int_val && (r).int_val) ? LCTrue : LCFalse)
+#define LC_OR(l, r) (((l).int_val || (r).int_val) ? LCTrue : LCFalse)
+
 #define LC_F32_EQ(l, r) MK_BOOL((l).float_val == (r).float_val)
 #define LC_F32_NOT_EQ(l, r) MK_BOOL((l).float_val != (r).float_val)
 #define LC_F32_LT(l, r) MK_BOOL((l).float_val < (r).float_val)


### PR DESCRIPTION
fix compiler crashing while parsing `&&` and `||`