### PR TITLE
Feat/literal improvement

### DIFF
--- a/examples/constant_folding/expect.txt
+++ b/examples/constant_folding/expect.txt
@@ -1,0 +1,16 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/examples/constant_folding/main.lc
+++ b/examples/constant_folding/main.lc
@@ -1,0 +1,39 @@
+// see constant folding result in compiled output.
+function main() {
+  // integer
+  const int1 = 1 + 2 + 4 + 11;
+  const int2 = 1 - 2 - 3 - 4;
+  const int3 = 1 + 4 / 2 + 3;
+  const int4 = (1 + 4) / (2 + 3);
+  const int5 = 1 + 4 / (2 + 2);
+  const int6 = 1 - (2 - 3) - 4;
+  const int7 = int1 + (int3 - int1) / 2;
+  // float
+  const float1 = 0.1 + 0.2;
+  const float2 = float1 / 0.3 * 0.3;
+  const float3 = 1.0 + 4.0 / 2.0 + 3.0;
+  const float4 = 1.0 - (2.0 - 3.0) - 4.0;
+  const float5 = float3 + (float4 - float3) / 2.0;
+  // string
+  const str1 = "1" + "2" + "3" + "4567" + "8";
+  const str2 = "LichenScript" + "真" + "好用！" + "😊";
+
+  print(int1 == 18);
+  print(int2 == -8);
+  print(int3 == 6);
+  print(int4 == 1);
+  print(int5 == 2);
+  print(int6 == -2);
+  print(int7 == 12);
+
+  print(float1 == 0.3);
+  print(float1 / 0.3 == 1.0);
+  print(float2 == float1);
+  print(float3 == 6.0);
+  print(float4 == -2.0);
+  print(float5 == 2.0);
+  print((1.0 / 3.0) * 3.0 == (1.0 * 3.0) / 3.0);
+
+  print(str1 == "12345678");
+  print(str2 == "LichenScript真好用！😊");
+}

--- a/examples/int_literals/expect.txt
+++ b/examples/int_literals/expect.txt
@@ -1,0 +1,5 @@
+expect 100_000 == 100000: true
+expect 0b10 == 2: true
+expect 0o73 == 59: true
+expect 077 == 63: true
+expect 0xff == 255: true

--- a/examples/int_literals/expect.txt
+++ b/examples/int_literals/expect.txt
@@ -1,5 +1,4 @@
 expect 100_000 == 100000: true
 expect 0b10 == 2: true
 expect 0o73 == 59: true
-expect 077 == 63: true
 expect 0xff == 255: true

--- a/examples/int_literals/main.lc
+++ b/examples/int_literals/main.lc
@@ -2,12 +2,10 @@ function main() {
   const decimal = 100_000;
   const binary = 0b10;
   const octal = 0o73;
-  const legacy_octal = 077;
   const hex = 0xff;
 
   print("expect 100_000 == 100000: ", decimal == 100000);
   print("expect 0b10 == 2: ", binary == 2);
   print("expect 0o73 == 59: ", octal == 59);
-  print("expect 077 == 63: ", legacy_octal == 63);
   print("expect 0xff == 255: ", hex == 255);
 }

--- a/examples/int_literals/main.lc
+++ b/examples/int_literals/main.lc
@@ -1,0 +1,13 @@
+function main() {
+  const decimal = 100_000;
+  const binary = 0b10;
+  const octal = 0o73;
+  const legacy_octal = 077;
+  const hex = 0xff;
+
+  print("expect 100_000 == 100000: ", decimal == 100000);
+  print("expect 0b10 == 2: ", binary == 2);
+  print("expect 0o73 == 59: ", octal == 59);
+  print("expect 077 == 63: ", legacy_octal == 63);
+  print("expect 0xff == 255: ", hex == 255);
+}

--- a/examples/string/expect.txt
+++ b/examples/string/expect.txt
@@ -8,3 +8,5 @@ gt: false
 lt2: false
 gt2: true
 chen
+https://www.lichenscript.com
+https://www.lichenscript.com

--- a/examples/string/main.lc
+++ b/examples/string/main.lc
@@ -2,7 +2,7 @@
 function main() {
     print("Hello World".length);
     print("你好世界".length);
-    let name = "LichenScript";
+    const name = "LichenScript";
     print("Hello " + name);
     print(name == "LichenScript");
     print(name == "LichenScript2");
@@ -11,4 +11,8 @@ function main() {
     print("lt2: ", "你好" > "nh");
     print("gt2: ", "你好" < "nh");
     print(name.slice(2, 6));
+    const url1 = "https://www." + "lichenscript.com";
+    const url2 = "https://www.lichenscript.com";
+    print(url1);
+    print(url2);
 }

--- a/lib/c_backend/c_op.ml
+++ b/lib/c_backend/c_op.ml
@@ -66,7 +66,7 @@ module%gen rec Decl : sig
   type enum_ctor = {
     enum_ctor_name: string;
     enum_ctor_tag_id: int;
-    enum_cotr_params_size: int;
+    enum_ctor_params_size: int;
   }
   [@@deriving show]
 

--- a/lib/c_backend/codegen.ml
+++ b/lib/c_backend/codegen.ml
@@ -324,7 +324,7 @@ and codegen_declaration env decl =
 
   | EnumCtor ctor -> (
     ps env (Format.sprintf "LCValue %s(LCRuntime* rt, LCValue this, int argv, LCValue* args) {\n" ctor.enum_ctor_name);
-    if ctor.enum_cotr_params_size = 0 then
+    if ctor.enum_ctor_params_size = 0 then
       ps env (Format.sprintf "    return MK_UNION(%d);\n" ctor.enum_ctor_tag_id)
     else (
       ps env (Format.sprintf "    return LCNewUnionObject(rt, %d, argv, args);\n" ctor.enum_ctor_tag_id)

--- a/lib/c_backend/transform.ml
+++ b/lib/c_backend/transform.ml
@@ -2221,7 +2221,7 @@ and transform_enum env enum loc : C_op.Decl.t list =
           let spec = C_op.Decl.EnumCtor {
             enum_ctor_name = new_name;
             enum_ctor_tag_id = index;
-            enum_cotr_params_size = List.length case.case_fields;
+            enum_ctor_params_size = List.length case.case_fields;
           } in
           [{ C_op.Decl. spec; loc }]
         )

--- a/lib/c_backend/transform.ml
+++ b/lib/c_backend/transform.ml
@@ -701,8 +701,9 @@ and transform_expression ?(is_move=false) ?(is_borrow=false) env expr =
       | String(content, _, _) -> 
         auto_release_expr env ~is_move ~append_stmts ty_var (C_op.Expr.NewString content)
 
-      | Integer(content, _) ->
-        C_op.Expr.NewInt content
+      | Integer content ->
+        let int_str = Int32.to_string content in
+        C_op.Expr.NewInt int_str
 
       | Boolean bl ->
         C_op.Expr.NewBoolean bl
@@ -913,8 +914,9 @@ and transform_expression ?(is_move=false) ?(is_borrow=false) env expr =
               | String(content, _, _) -> 
                 auto_release_expr env ~is_move:false ~append_stmts ty_var (C_op.Expr.NewString content)
 
-              | Integer(content, _) ->
-                C_op.Expr.NewInt content
+              | Integer content ->
+                let int_str = Int32.to_string content in
+                C_op.Expr.NewInt int_str
 
               | _ ->
                 failwith "unimplemented"
@@ -1463,8 +1465,9 @@ and transform_pattern_matching env ~prepend_stmts ~append_stmts ~loc ~ty_var _ma
     | Underscore ->
       (fun genereator -> genereator ~finalizers:[] ())
 
-    | Literal (Literal.Integer(i, _)) -> (
-      let if_test = C_op.Expr.IntValue(I32Binary(BinaryOp.Equal, match_expr, NewInt i)) in
+    | Literal (Literal.Integer i) -> (
+      let i_str = Int32.to_string i in
+      let if_test = C_op.Expr.IntValue(I32Binary(BinaryOp.Equal, match_expr, NewInt i_str)) in
       (fun genereator ->
         let if_stmt = { C_op.Stmt.
           spec = If {

--- a/lib/parsing/ast.ml
+++ b/lib/parsing/ast.ml
@@ -23,14 +23,12 @@ module%gen rec Literal : sig
 
   type t =
     | Unit
-    | Integer of string * char option
-
+    | Integer of int32 (* TODO: support i64 *)
     (*
      * `char` is representing a 8-bit char in OCaml,
      * but char is UTF-16 in LichenScript
      *)
     | Char of int
-
     (* 'c' *)
     | String of string * Loc.t * string option
     | Float of string * char option

--- a/lib/parsing/parser.ml
+++ b/lib/parsing/parser.ml
@@ -1145,7 +1145,7 @@ and parse_binary_expression env : Expression.t =
   let open Expression in
   let rec parse_binary_enhance env left_expr left_token =
     let start_loc = Peek.loc env in
-    let expr = parse_exponentialtion_expression env in
+    let expr = parse_exponentiation_expression env in
     let left_prec = Precedence.binary_precedence left_token in
     let right_token = Peek.token env in
     let right_prec = Precedence.binary_precedence right_token in
@@ -1195,7 +1195,7 @@ and parse_binary_expression env : Expression.t =
     )
   in
 
-  let expr = parse_exponentialtion_expression env in
+  let expr = parse_exponentiation_expression env in
   let next = Peek.token env in
   let prec = Precedence.binary_precedence next in
   if prec > 0 then
@@ -1206,7 +1206,7 @@ and parse_binary_expression env : Expression.t =
   else
     expr
 
-and parse_exponentialtion_expression env =
+and parse_exponentiation_expression env =
   parse_unary_expression env
 
 and parse_unary_expression env: Expression.t =

--- a/lib/parsing/parser.ml
+++ b/lib/parsing/parser.ml
@@ -1341,7 +1341,8 @@ and parse_literal env =
     if String.contains raw '.' then
       Literal.Float (raw, None)
     else
-      Literal.Integer (raw, None)
+      (* TODO: support i64 *)
+      Literal.Integer (Int32.of_string raw)
   )
 
   | Token.T_CHAR(_, ch, _) ->

--- a/lib/typing/check_helper.ml
+++ b/lib/typing/check_helper.ml
@@ -335,14 +335,18 @@ let is_array ctx type_expr =
 
 let is_primitive_with_name ctx ~name:expect_name type_expr =
   let type_expr = Type_context.deref_type ctx type_expr in
-  let expr_def_opt = find_construct_of ctx type_expr in
-  (match expr_def_opt with
-    | Some(def, []) -> (
-      let open TypeDef in
-      def.builtin &&
-      String.equal def.name expect_name
-    )
-    | _ -> false
+  (match type_expr with
+    | String -> String.equal expect_name "string"
+    | _ ->
+      let expr_def_opt = find_construct_of ctx type_expr in
+      match expr_def_opt with
+        | Some(def, []) -> (
+          let open TypeDef in
+          def.builtin &&
+          String.equal def.name expect_name
+        )
+
+        | _ -> false
   )
 
 let is_unit = is_primitive_with_name ~name:"unit"
@@ -358,6 +362,11 @@ let is_f64 = is_primitive_with_name ~name:"f64"
 let is_char = is_primitive_with_name ~name:"char"
 
 let is_boolean = is_primitive_with_name ~name:"boolean"
+
+let is_string type_expr = 
+  match type_expr with
+  | TypeExpr.String -> true
+  | _ -> false
 
 let rec replace_type_vars_with_maps ctx type_map type_expr =
   let open Core_type.TypeExpr in

--- a/lib/typing/typecheck.ml
+++ b/lib/typing/typecheck.ml
@@ -627,9 +627,17 @@ and check_expression env expr =
       | _ -> raise_err()
     )
 
-    | Asttypes.UnaryOp.Plus
-    | Asttypes.UnaryOp.Minus -> (
+    | Asttypes.UnaryOp.Minus ->
       if not (Check_helper.is_i32 env.ctx node_type) && not (Check_helper.is_f32 env.ctx node_type) then (
+        raise_err ()
+      );
+      Type_context.update_node_type env.ctx expr.ty_var node_type
+    | Asttypes.UnaryOp.Plus -> (
+      if
+        not (Check_helper.is_i32 env.ctx node_type) &&
+        not (Check_helper.is_f32 env.ctx node_type) &&
+        not (Check_helper.is_string node_type)
+      then (
         raise_err ()
       );
       Type_context.update_node_type env.ctx expr.ty_var node_type


### PR DESCRIPTION
This PR mainly contains:
## Features
### Hex / Octal / Binary number support
We can write hex number like 0xff(decimal 255), octal number like 0o73(decimal 59), binary number like 0b10(decimal 2), which are similar to JavaScript.

Since lexer does not support legacy octal number (which means prefixed by literal zero `0` but no lower case of O `o` right after, being dropped since [this commit](https://github.com/lichenscript/lichenscript/commit/162ff1d1849cd2986b9ad5c9b88436fa0eb3a9fc)), transform.ml does not handle it too.
### Constant folding support
In master branch. 
```js
const num1 = 1 + 2;
```
will be compiled to
```c
LCValue num1;
num1 = LC_I32_PLUS(MK_I32(1), MK_I32(2));
```
now, it will be
```c
LCValue num1;
num1 = MK_I32(3);
```
If you write code like:
```js
const num1 = 1 + 2 + 3;
```
Before:
```c
LCValue num1;
num1 = LC_I32_PLUS(LC_I32_PLUS(MK_I32(1), MK_I32(2)), MK_I32(3));
```
After:
```c
LCValue num1;
num1 = MK_I32(6);
```
**Furthermore**, If it is string concatation like:
```js
const str1 = "1" + "2" + "3";
```
Before:
```c
LCValue t[4] = {0};
LCValue str1;
// ** pay attention to such a long long code line below ** 
str1 = lc_std_string_concat(rt, MK_NULL(), 2, (LCValue[]) {t[2] = lc_std_string_concat(rt, MK_NULL(), 2, (LCValue[]) {t[0] = LCNewStringFromCStringLen(rt, (const unsigned char*)"1", 1), t[1] = LCNewStringFromCStringLen(rt, (const unsigned char*)"2", 1)}), t[3] = LCNewStringFromCStringLen(rt, (const unsigned char*)"3", 1)});
LCRelease(rt, t[2]);
LCRelease(rt, t[0]);
LCRelease(rt, t[1]);
LCRelease(rt, t[3]);
LCRelease(rt, str1);
```
After:
```c
LCValue t[1] = {0};
LCValue str1;
str1 = t[0] = LCNewStringFromCStringLen(rt, (const unsigned char*)"123", 3);
LCRelease(rt, str1);
```
Less code, less runtime overheads 🎉.

This optimization works in all binary operation between constant literals. Please see more in `examples/constant_folding`, and compare the differences between output of each branch.

## Fixes
Just fix typos like `enum_cotr_params_size` -> `enum_ctor_params_size`, `exponentialtion` -> `exponentiation`. Nothing else special 😃.



  