### PR TITLE
Feat/support try syntax

### DIFF
--- a/examples/errors/try_expr_return_error_type/error.txt
+++ b/examples/errors/try_expr_return_error_type/error.txt
@@ -1,0 +1,1 @@
+20:38 Type 'Result<unit, B>' can not be returned because 'unit' is expected

--- a/examples/errors/try_expr_return_error_type/main.lc
+++ b/examples/errors/try_expr_return_error_type/main.lc
@@ -1,4 +1,5 @@
 
+
 class MyError {
 
   msg: string
@@ -16,7 +17,7 @@ function test2(content: string): Result<i32, MyError> {
   }
 }
 
-function test1(content: string): Result<unit, MyError> {
+function test1(content: string): unit {
   const num = test2(content)?;
   print(num);
   Ok(())

--- a/examples/try_expr/main.lc
+++ b/examples/try_expr/main.lc
@@ -1,0 +1,23 @@
+
+class MyError {
+
+}
+
+function test2(content: string): Result<i32, MyError> {
+	if content.length == 0 {
+		const err: Result<i32, Error> = Error(MyError{});
+		err
+	} else {
+		Ok(0)
+	}
+}
+
+function test1(content: string): Result<unit, MyError> {
+	const num = test2(content)?;
+	print(num);
+	Ok(())
+}
+
+function main() {
+	test1("some");
+}

--- a/examples/try_expr/main.lc
+++ b/examples/try_expr/main.lc
@@ -1,11 +1,15 @@
 
 class MyError {
 
+	msg: string
+
 }
 
 function test2(content: string): Result<i32, MyError> {
 	if content.length == 0 {
-		const err: Result<i32, Error> = Error(MyError{});
+		const err: Result<i32, Error> = Error(MyError{
+			msg: "null string"
+		});
 		err
 	} else {
 		Ok(0)
@@ -20,4 +24,9 @@ function test1(content: string): Result<unit, MyError> {
 
 function main() {
 	test1("some");
+	const result2 = test1("");
+	match result2 {
+		case Error(myErr) => print(myErr.msg)
+		case _ => print("no error")
+	}
 }

--- a/lib/c_backend/transform.ml
+++ b/lib/c_backend/transform.ml
@@ -1355,6 +1355,8 @@ and transform_expression ?(is_move=false) ?(is_borrow=false) env expr =
         C_op.Expr.Ident SymThis
     )
 
+    | Try _expr -> failwith "unimplemented: try"
+
     | Super -> failwith "not implemented: super"
 
     | Index(expr, index) -> (

--- a/lib/lex/lex.ml
+++ b/lib/lex/lex.ml
@@ -894,13 +894,6 @@ let token (env : Lex_env.t) lexbuf : result =
   | ";" -> Token (env, T_SEMICOLON)
   | "," -> Token (env, T_COMMA)
   | ":" -> Token (env, T_COLON)
-  | ("?.", digit) ->
-    Sedlexing.rollback lexbuf;
-    (match%sedlex lexbuf with
-    | "?" -> Token (env, T_PLING)
-    | _ -> failwith "expected ?")
-  | "?." -> Token (env, T_PLING_PERIOD)
-  | "??" -> Token (env, T_PLING_PLING)
   | "?" -> Token (env, T_PLING)
   | "&&" -> Token (env, T_AND)
   | "||" -> Token (env, T_OR)
@@ -1729,7 +1722,6 @@ let type_token env lexbuf =
   | ";" -> Token (env, T_SEMICOLON)
   | "," -> Token (env, T_COMMA)
   | ":" -> Token (env, T_COLON)
-  | "?." -> Token (env, T_PLING_PERIOD)
   | "?" -> Token (env, T_PLING)
   | "[" -> Token (env, T_LBRACKET)
   | "]" -> Token (env, T_RBRACKET)

--- a/lib/lex/token.ml
+++ b/lib/lex/token.ml
@@ -92,8 +92,6 @@ type t =
   | T_MINUS_ASSIGN
   | T_PLUS_ASSIGN
   | T_ASSIGN
-  | T_PLING_PERIOD
-  | T_PLING_PLING
   | T_PLING
   | T_COLON
   | T_OR
@@ -257,8 +255,6 @@ let token_to_string = function
   | T_MINUS_ASSIGN -> "T_MINUS_ASSIGN"
   | T_PLUS_ASSIGN -> "T_PLUS_ASSIGN"
   | T_ASSIGN -> "T_ASSIGN"
-  | T_PLING_PERIOD -> "T_PLING_PERIOD"
-  | T_PLING_PLING -> "T_PLING_PLING"
   | T_PLING -> "T_PLING"
   | T_COLON -> "T_COLON"
   | T_OR -> "T_OR"
@@ -383,8 +379,6 @@ let value_of_token = function
   | T_MINUS_ASSIGN -> "-="
   | T_PLUS_ASSIGN -> "+="
   | T_ASSIGN -> "="
-  | T_PLING_PERIOD -> "?."
-  | T_PLING_PLING -> "??"
   | T_PLING -> "?"
   | T_COLON -> ":"
   | T_OR -> "||"

--- a/lib/parsing/ast.ml
+++ b/lib/parsing/ast.ml
@@ -116,6 +116,7 @@ and Expression : sig
     | Block of Block.t
     | Init of init
     | Match of _match
+    | Try of t
     | This
     | Super
 

--- a/lib/parsing/parser.ml
+++ b/lib/parsing/parser.ml
@@ -1309,6 +1309,20 @@ and parse_left_handside_expression_allow_call env : Expression.t =
       in
       loop env expr
 
+    | Token.T_PLING ->
+      begin
+        Eat.token env;
+        let spec = Try expr in
+        let expr =
+          {
+            spec;
+            loc = with_start_loc env start_pos;
+            attributes = [];
+          }
+        in
+        loop env expr
+      end
+
     (* | Token.T_LCURLYBAR *)
 
     | _ -> expr

--- a/lib/typing/annotate.ml
+++ b/lib/typing/annotate.ml
@@ -515,6 +515,18 @@ and annotate_expression ~prev_deps env expr : T.Expression.t =
 
     | Match _match -> annotate_expression_match ~prev_deps env _match
 
+    | Try expr -> (
+      let expr' = annotate_expression ~prev_deps env expr in
+      let node = {
+        value = TypeExpr.Unknown;
+        loc;
+        deps = [expr'.ty_var];
+      } in
+
+      let node_id = Type_context.new_id (Env.ctx env) node in
+      node_id, (T.Expression.Try expr')
+    )
+
     | This -> (
       let scope = Env.peek_scope env in
       let this_expr = scope#this_expr in

--- a/lib/typing/check_helper.ml
+++ b/lib/typing/check_helper.ml
@@ -135,8 +135,10 @@ let rec type_assinable_with_maps ctx var_maps left right =
           ~init:(var_maps, true)
           ~f:(fun acc left right ->
             let var_names, acc' = acc in
-            match right with
-            | TypeSymbol _ -> acc
+            match (left, right) with
+            | (TypeSymbol _, _)
+            | (_, TypeSymbol _)
+              -> acc
             | _ -> (
               if (not acc') then
                 acc

--- a/lib/typing/diagnosis.ml
+++ b/lib/typing/diagnosis.ml
@@ -166,6 +166,9 @@ module PP = struct
 
     | IfTestShouldBeBoolean ty ->
       Format.fprintf formatter "The type of expression after if should be 'boolean', but got '%s'." (pp_ty ty)
+    
+    | CannotUsedForTryExpression ty ->
+      Format.fprintf formatter "The type '%s' can not be used in a try expression." (pp_ty ty)
 
   let error ~ctx formatter diagnosis =
     let { spec; loc; _ } = diagnosis in

--- a/lib/typing/type_error.ml
+++ b/lib/typing/type_error.ml
@@ -40,3 +40,4 @@ type t =
   | PatternNotExausted
   | WhileTestShouldBeBoolean of TypeExpr.t
   | IfTestShouldBeBoolean of TypeExpr.t
+  | CannotUsedForTryExpression of TypeExpr.t

--- a/lib/typing/typecheck.ml
+++ b/lib/typing/typecheck.ml
@@ -951,6 +951,10 @@ and check_expression env expr =
     Type_context.update_node_type env.ctx expr.ty_var ty
   )
 
+  | Try expr -> (
+    check_expression env expr;
+  )
+
   | This
   | Super -> ()
 

--- a/lib/typing/typedtree.ml
+++ b/lib/typing/typedtree.ml
@@ -111,6 +111,7 @@ module%gen rec Expression : sig
     | Block of Block.t
     | Init of init
     | Match of _match
+    | Try of t
     | This
     | Super
 


### PR DESCRIPTION
- Support try syntax

```
function test1(content: string): Result<unit, MyError> {
  const num = test2(content)?;
  print(num);
  Ok(())
}
```
- Only used for `Result` type for testing