### PR TITLE
Feat/import namespace

### DIFF
--- a/examples/cyclic_function/main.lc
+++ b/examples/cyclic_function/main.lc
@@ -1,20 +1,20 @@
 
-function A() {
-    B();
+function a() {
+    b();
 }
 
-function B() {
-    C(false);
+function b() {
+    c(false);
 }
 
-function C(callA: boolean) {
+function c(callA: boolean) {
     if callA {
-        A()
+        a()
     } else {
         print("finished")
     }
 }
 
 function main() {
-    C(true);
+    c(true);
 }

--- a/examples/errors/enum_method_case/error.txt
+++ b/examples/errors/enum_method_case/error.txt
@@ -1,0 +1,1 @@
+5:2 Lowercase the first char of the method name 'Show' of the enum 'Num'

--- a/examples/errors/enum_method_case/main.lc
+++ b/examples/errors/enum_method_case/main.lc
@@ -1,0 +1,14 @@
+
+enum Num {
+  case One
+
+  Show() {
+
+  }
+
+}
+
+function main() {
+  const a = One;
+  a.Show();
+}

--- a/examples/errors/import_can_not_resolve/error.txt
+++ b/examples/errors/import_can_not_resolve/error.txt
@@ -1,1 +1,1 @@
-1:7 Can not resolve symbol 'xxx'
+1:14 Can not resolve symbol 'xxx'

--- a/examples/errors/import_can_not_resolve/main.lc
+++ b/examples/errors/import_can_not_resolve/main.lc
@@ -1,4 +1,4 @@
-import "xxx"
+import * from "xxx"
 
 function main() {
 	const tiger = Tiger{};

--- a/examples/errors/import_redecalred_symbol/error.txt
+++ b/examples/errors/import_redecalred_symbol/error.txt
@@ -1,1 +1,1 @@
-1:7 'test' redecalred in this module
+1:14 'test' redecalred in this module

--- a/examples/errors/import_redecalred_symbol/main.lc
+++ b/examples/errors/import_redecalred_symbol/main.lc
@@ -1,4 +1,4 @@
-import "anotherLib";
+import * from "anotherLib";
 
 function test() {
 	print("my test");

--- a/examples/errors/import_uppercase_namespace/error.txt
+++ b/examples/errors/import_uppercase_namespace/error.txt
@@ -1,1 +1,1 @@
-1:7 Lowercase the import name 'Lib'
+1:7 Lowercase the first char of the import name 'Lib'

--- a/examples/errors/import_uppercase_namespace/error.txt
+++ b/examples/errors/import_uppercase_namespace/error.txt
@@ -1,0 +1,1 @@
+1:7 Lowercase the import name 'Lib'

--- a/examples/errors/import_uppercase_namespace/main.lc
+++ b/examples/errors/import_uppercase_namespace/main.lc
@@ -1,0 +1,5 @@
+import Lib from "anotherLib";
+
+function main () {
+  Lib.test();
+}

--- a/examples/errors/import_uppercase_namespace/node_modules/anotherLib/lib.lc
+++ b/examples/errors/import_uppercase_namespace/node_modules/anotherLib/lib.lc
@@ -1,0 +1,4 @@
+
+public function test() {
+	print("Hello World");
+}

--- a/examples/errors/lowercase_function_name/error.txt
+++ b/examples/errors/lowercase_function_name/error.txt
@@ -1,0 +1,1 @@
+2:9 Lowercase the first char of the function name 'Test'

--- a/examples/errors/lowercase_function_name/main.lc
+++ b/examples/errors/lowercase_function_name/main.lc
@@ -1,0 +1,8 @@
+
+function Test() {
+	print("Hello world");
+}
+
+function main() {
+	Test();
+}

--- a/examples/import_namespace/expect.txt
+++ b/examples/import_namespace/expect.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/examples/import_namespace/main.lc
+++ b/examples/import_namespace/main.lc
@@ -1,0 +1,5 @@
+import Lib from "anotherLib";
+
+function main () {
+  Lib.test();
+}

--- a/examples/import_namespace/main.lc
+++ b/examples/import_namespace/main.lc
@@ -1,5 +1,5 @@
-import Lib from "anotherLib";
+import lib from "anotherLib";
 
 function main () {
-  Lib.test();
+  lib.test();
 }

--- a/examples/import_namespace/node_modules/anotherLib/lib.lc
+++ b/examples/import_namespace/node_modules/anotherLib/lib.lc
@@ -1,0 +1,4 @@
+
+public function test() {
+	print("Hello World");
+}

--- a/examples/test_node_modules/main.lc
+++ b/examples/test_node_modules/main.lc
@@ -1,5 +1,5 @@
 import * from "anotherLib";
 
 function main () {
-	test();
+  test();
 }

--- a/examples/test_node_modules/main.lc
+++ b/examples/test_node_modules/main.lc
@@ -1,4 +1,4 @@
-import "anotherLib";
+import * from "anotherLib";
 
 function main () {
 	test();

--- a/lib/ir/transform.ml
+++ b/lib/ir/transform.ml
@@ -923,7 +923,7 @@ and transform_expression ?(is_move=false) ?(is_borrow=false) env expr =
       env.tmp_vars_count <- env.tmp_vars_count + 1;
       let tmp_var = Ir.SymTemp tmp_id in
 
-      if Check_helper.is_unit env.ctx (Type_context.deref_node_type env.ctx ty_var) then (
+      if Check_helper.is_unit (Type_context.deref_node_type env.ctx ty_var) then (
         let init_stmt = { Ir.Stmt.
           spec = Expr(Ir.Expr.Assign(Ident tmp_var, Null));
           loc = Loc.none;

--- a/lib/ir/transform.ml
+++ b/lib/ir/transform.ml
@@ -1123,12 +1123,12 @@ and transform_expression ?(is_move=false) ?(is_borrow=false) env expr =
             let member = Check_helper.find_member_of_type env.ctx ~scope:(Option.value_exn env.scope.raw) expr_type id.pident_name in
             match member with
             | Some ((Method ({ spec = ClassMethod { method_is_virtual = true; _ }; _ }, _, _)), _) -> (
-                let this_expr = transform_expression ~is_borrow:true env expr in
+              let this_expr = transform_expression ~is_borrow:true env expr in
 
-                prepend_stmts := List.append !prepend_stmts this_expr.prepend_stmts;
-                append_stmts := List.append !append_stmts this_expr.append_stmts;
+              prepend_stmts := List.append !prepend_stmts this_expr.prepend_stmts;
+              append_stmts := List.append !append_stmts this_expr.append_stmts;
 
-                Ir.Expr.Invoke(this_expr.expr, id.pident_name, params)
+              Ir.Expr.Invoke(this_expr.expr, id.pident_name, params)
             )
             | Some ((Method ({ id = method_id; spec = ClassMethod { method_get_set = None; _ }; _ }, _, _)), _) -> (
               (* only class method needs a this_expr, this is useless for a static function *)

--- a/lib/lex/lex.ml
+++ b/lib/lex/lex.ml
@@ -847,6 +847,7 @@ let token (env : Lex_env.t) lexbuf : result =
   | "extends" -> Token (env, T_EXTENDS)
   | "false" -> Token (env, T_FALSE)
   | "final" -> Token (env, T_FINAL)
+  | "from" -> Token (env, T_FROM)
   | "for" -> Token (env, T_FOR)
   | "function" -> Token (env, T_FUNCTION)
   | "if" -> Token (env, T_IF)

--- a/lib/lex/token.ml
+++ b/lib/lex/token.ml
@@ -62,6 +62,7 @@ type t =
   | T_MATCH
   | T_EXPORT
   | T_IMPORT
+  | T_FROM
   | T_SUPER
   | T_IMPLEMENTS
   | T_INTERFACE
@@ -213,6 +214,7 @@ let token_to_string = function
   | T_MATCH -> "T_MATCH"
   | T_EXPORT -> "T_EXPORT"
   | T_IMPORT -> "T_IMPORT"
+  | T_FROM -> "T_FROM"
   | T_SUPER -> "T_SUPER"
   | T_IMPLEMENTS -> "T_IMPLEMENTS"
   | T_INTERFACE -> "T_INTERFACE"
@@ -350,6 +352,7 @@ let value_of_token = function
   | T_MATCH -> "match"
   | T_EXPORT -> "export"
   | T_IMPORT -> "import"
+  | T_FROM -> "from"
   | T_SUPER -> "super"
   | T_IMPLEMENTS -> "implements"
   | T_INTERFACE -> "interface"

--- a/lib/parsing/ast.ml
+++ b/lib/parsing/ast.ml
@@ -367,11 +367,6 @@ and Declaration : sig
   }
   [@@deriving show]
 
-  type import = {
-    source: string;
-    source_loc: Loc.t;
-  }
-  [@@deriving show]
 
   type spec =
     | Class of _class
@@ -379,7 +374,7 @@ and Declaration : sig
     | Function_ of Function.t
     | Declare of declare
     | Enum of Enum.t
-    | Import of import
+    | Import of Import.t
     [@@deriving show]
 
   type t = {
@@ -391,6 +386,23 @@ and Declaration : sig
 
 end
   = Declaration
+
+and Import : sig
+
+  type spec =
+  | ImportAll
+  | ImportNamespace of Identifier.t
+  [@@deriving show]
+
+  type t = {
+    spec: spec option;
+    source: string;
+    source_loc: Loc.t;
+  }
+  [@@deriving show]
+
+end
+  =Import
 
 type program = {
   pprogram_top_level: Top_level.t;

--- a/lib/parsing/parser.ml
+++ b/lib/parsing/parser.ml
@@ -251,7 +251,13 @@ and parse_import env : Import.t =
   )
 
   | _ ->
-    import_tail_with_spec None
+    let perr_spec = Parser_env.get_unexpected_error next in
+    let perr_loc = Peek.loc env in
+    Parse_error.error {
+      perr_spec;
+      perr_loc;
+    }
+    (* import_tail_with_spec None *)
 
 and parse_declaration env : Declaration.t =
   let open Declaration in

--- a/lib/parsing/parser.ml
+++ b/lib/parsing/parser.ml
@@ -247,6 +247,7 @@ and parse_import env : Import.t =
 
   | Token.T_IDENTIFIER _ -> (
     let id = parse_identifier env in
+    Expect.token env Token.T_FROM;
     import_tail_with_spec (Some (ImportNamespace id))
   )
 

--- a/lib/resolver/resolver.ml
+++ b/lib/resolver/resolver.ml
@@ -198,8 +198,8 @@ module S (FS: FSProvider) = struct
         )
         ast.tree.pprogram_declarations
       in
-      let preclude = {
-        Ast.Declaration.
+      let preclude = { Ast.Import.
+        spec = None;
         source = "std/preclude";
         source_loc = Loc.none;
       } in
@@ -211,8 +211,8 @@ module S (FS: FSProvider) = struct
 
     List.iter
       ~f:(fun import ->
-        let open Ast.Declaration in
-        let { source; source_loc } = import in
+        let open Ast.Import in
+        let { source; source_loc; _ } = import in
         let find_paths = env.find_paths in
         let result =
           List.fold
@@ -331,7 +331,7 @@ module S (FS: FSProvider) = struct
       )
       env.linker
 
-  let import_checker env _mod file (import: Ast.Declaration.import) =
+  let import_checker env _mod file (import: Ast.Import.t) =
     let { Module. imports_map; _ } = file in
     let module_full_path = Hashtbl.find_exn imports_map import.source in
     let _module = Option.value_exn (Linker.get_module env.linker module_full_path) in

--- a/lib/typing/annotate.ml
+++ b/lib/typing/annotate.ml
@@ -1663,7 +1663,7 @@ and annotate_enum env enum =
 
       let first_char = String.get case_name.pident_name 0 in
       if not (Char.is_uppercase first_char) then (
-        let err = Diagnosis.(make_error ctx case_name.pident_loc (CapitalizedEnumMemeber case_name.pident_name)) in
+        let err = Diagnosis.(make_error ctx case_name.pident_loc (CapitalizedEnumMember case_name.pident_name)) in
         raise (Diagnosis.Error err)
       );
 
@@ -1928,6 +1928,17 @@ and annotate_import env import =
   match spec with
   | Some (ImportNamespace local_name) -> (
     let id = Type_context.size (Env.ctx env) in
+
+    let first_char = String.get local_name.pident_name 0 in
+    if Char.is_uppercase first_char then (
+      let err = Diagnosis.(make_error
+        (Env.ctx env)
+        local_name.pident_loc
+        (LowercaseTheImportName local_name.pident_name)
+      ) in
+      raise Diagnosis.(Error err)
+    );
+
     let type_def = { Core_type.TypeDef.
       id;
       builtin = false;

--- a/lib/typing/annotate.ml
+++ b/lib/typing/annotate.ml
@@ -1026,6 +1026,16 @@ and annotate_class env cls =
         | Cls_method _method -> (
           let method_scope = new function_scope ~prev:(Env.peek_scope env) () in
           let { cls_method_attributes; cls_method_visibility; cls_method_modifier; cls_method_name; cls_method_params; cls_method_loc; cls_method_body; cls_method_return_ty; _ } = _method in
+
+          let first_char = String.get cls_method_name.pident_name 0 in
+          if Char.is_uppercase first_char then (
+            let err = Diagnosis.(make_error
+              (Env.ctx env) cls_method_name.pident_loc
+              (LowercaseTheMethod ("class", cls.cls_id.pident_name, _method.cls_method_name.pident_name)))
+            in
+            raise (Diagnosis.Error err)
+          );
+
           let type_visibility = annotate_visibility cls_method_visibility in
           let is_static =
             match cls_method_modifier with
@@ -1568,6 +1578,15 @@ and annotate_function env fun_ =
   Env.with_new_scope env fun_scope (fun env ->
     let { visibility = _visibility; header; body; loc; comments; } = fun_ in
 
+    let first_char = String.get header.id.pident_name 0 in
+    if Char.is_uppercase first_char then (
+      let err = Diagnosis.(make_error
+        (Env.ctx env) header.id.pident_loc
+        (LowercaseTheFunctionName header.id.pident_name))
+      in
+      raise (Diagnosis.Error err)
+    );
+
     let fun_id_opt = prev_scope#find_var_symbol header.id.pident_name in
     if Option.is_none fun_id_opt then (
       failwith (Format.sprintf "unexpected: function id %s is not added in parsing stage" header.id.pident_name)
@@ -1720,6 +1739,16 @@ and annotate_enum env enum =
       let open Ast.Declaration in
       let method_scope = new function_scope ~prev:(Env.peek_scope env) () in
       let { cls_method_attributes; cls_method_visibility; cls_method_modifier; cls_method_name; cls_method_params; cls_method_loc; cls_method_body; cls_method_return_ty; _ } = _method in
+
+      let first_char = String.get cls_method_name.pident_name 0 in
+      if Char.is_uppercase first_char then (
+        let err = Diagnosis.(make_error
+          (Env.ctx env) cls_method_name.pident_loc
+          (LowercaseTheMethod ("enum", name.pident_name, _method.cls_method_name.pident_name)))
+        in
+        raise (Diagnosis.Error err)
+      );
+
       let type_visibility = annotate_visibility cls_method_visibility in
       Env.with_new_scope env method_scope (fun env ->
         let cls_method_params, method_params, cls_method_params_deps = annotate_function_params env cls_method_params in

--- a/lib/typing/annotate.mli
+++ b/lib/typing/annotate.mli
@@ -1,5 +1,7 @@
 
 val is_name_enum_or_class: string -> bool
 
-val annotate_program: Env.t -> Lichenscript_parsing.Ast.program
--> Typedtree.program
+val annotate_program:
+  Env.t ->
+  Lichenscript_parsing.Ast.program ->
+  Typedtree.program

--- a/lib/typing/check_helper.ml
+++ b/lib/typing/check_helper.ml
@@ -386,10 +386,6 @@ let rec replace_type_vars_with_maps ctx type_map type_expr =
     | None -> type_expr
   )
 
-  | Unknown
-  | Unit
-  | Any -> type_expr
-
   | Ctor (m, list) -> (
     let m = replace_type_vars_with_maps ctx type_map m in
     let list = List.map ~f:(replace_type_vars_with_maps ctx type_map) list in
@@ -415,8 +411,6 @@ let rec replace_type_vars_with_maps ctx type_map type_expr =
     Lambda ({ params_content; params_rest }, ret)
   )
 
-  | Method _ -> type_expr
-
   | Tuple children ->
     let children = List.map ~f:(replace_type_vars_with_maps ctx type_map) children in
     Tuple children
@@ -424,7 +418,11 @@ let rec replace_type_vars_with_maps ctx type_map type_expr =
   | Array arr ->
     Array (replace_type_vars_with_maps ctx type_map arr)
 
-  | String -> type_expr
+  | Unknown
+  | Unit
+  | Any
+  | Method _
+  | String
   | TypeDef _ -> type_expr
 
 and replace_params_with_type ctx type_map params =
@@ -485,6 +483,10 @@ let rec find_member_of_class ctx ~scope type_expr member_name type_vars =
 
     result >>= fun (_name, _vis, elm) ->
     match elm with
+    | { TypeDef. id = _member_id; spec = Namespace _ns_path; _ } -> (
+      failwith "unimplemented"
+    )
+
     | ({ TypeDef. id = member_id; spec = ClassMethod { method_params; method_return; _ }; _ } as def) -> (
         let params = replace_params_with_type ctx types_map method_params in
         let rt = replace_type_vars_with_maps ctx types_map method_return in

--- a/lib/typing/core_type.ml
+++ b/lib/typing/core_type.ml
@@ -48,6 +48,8 @@ module rec TypeExpr : sig
     | Unknown
     | Any
 
+    | Unit
+
     (*
      * Ctor represents `instance`, does not represent the type itself
      *
@@ -118,6 +120,7 @@ end = struct
   type t =
     | Unknown
     | Any
+    | Unit
     | Ctor of t * (t list)
     | Ref of int
     | Lambda of params * t
@@ -138,6 +141,8 @@ end = struct
     match t with
     | Unknown -> Format.fprintf formatter "unknown"
     | Any -> Format.fprintf formatter "any"
+
+    | Unit -> Format.fprintf formatter "unit"
 
     | Ctor(t, vars) ->
       Format.fprintf formatter "%a<%d>" pp t (List.length vars)

--- a/lib/typing/core_type.ml
+++ b/lib/typing/core_type.ml
@@ -235,6 +235,7 @@ and TypeDef : sig
     | Function of _function
     | Enum of enum_type
     | EnumCtor of enum_ctor
+    | Namespace of string
 
   and t = {
     id: int;
@@ -319,6 +320,7 @@ end = struct
     | Function of _function
     | Enum of enum_type
     | EnumCtor of enum_ctor
+    | Namespace of string
 
   and t = {
     id: int;

--- a/lib/typing/diagnosis.ml
+++ b/lib/typing/diagnosis.ml
@@ -63,6 +63,9 @@ module PP = struct
     | CannotAccessBeforeInit var_name ->
       Format.fprintf formatter "Cannot access '%s' before initialization." var_name
 
+    | CannotFindNameForImport(local_name, find_name) ->
+      Format.fprintf formatter "Cannot find '%s' for module '%s'." find_name local_name
+
     | MissingMethodForInterface(intf_name, method_name) ->
       Format.fprintf formatter "Missing method '%s' for interface '%s'." method_name intf_name
 

--- a/lib/typing/diagnosis.ml
+++ b/lib/typing/diagnosis.ml
@@ -129,7 +129,7 @@ module PP = struct
     )
 
     | LowercaseTheImportName import_name ->
-      Format.fprintf formatter "Lowercase the import name '%s'" import_name
+      Format.fprintf formatter "Lowercase the first char of the import name '%s'" import_name
 
     | NotAEnumConstructor name -> (
       Format.fprintf formatter "'%s' is not an enum constructor" name

--- a/lib/typing/diagnosis.ml
+++ b/lib/typing/diagnosis.ml
@@ -131,6 +131,12 @@ module PP = struct
     | LowercaseTheImportName import_name ->
       Format.fprintf formatter "Lowercase the first char of the import name '%s'" import_name
 
+    | LowercaseTheFunctionName fun_name ->
+      Format.fprintf formatter "Lowercase the first char of the function name '%s'" fun_name
+
+    | LowercaseTheMethod (cls_or_enum, cls_name, method_name) ->
+      Format.fprintf formatter "Lowercase the first char of the method name '%s' of the %s '%s'" method_name cls_or_enum cls_name
+
     | NotAEnumConstructor name -> (
       Format.fprintf formatter "'%s' is not an enum constructor" name
     )

--- a/lib/typing/diagnosis.ml
+++ b/lib/typing/diagnosis.ml
@@ -121,12 +121,15 @@ module PP = struct
       Format.fprintf formatter "All the cases of match expression should return the same type, previous is %s, but got %s"
         (pp_ty prev) (pp_ty current)
 
-    | CapitalizedEnumMemeber name -> (
+    | CapitalizedEnumMember name -> (
       let first_char = String.get name 0 in
       let upper_char = Char.uppercase_ascii first_char in
       let new_name = String.mapi (fun index ch -> if index = 0 then upper_char else ch) name in
       Format.fprintf formatter "The name of the enum member '%s' must be capitalized, try '%s'" name new_name
     )
+
+    | LowercaseTheImportName import_name ->
+      Format.fprintf formatter "Lowercase the import name '%s'" import_name
 
     | NotAEnumConstructor name -> (
       Format.fprintf formatter "'%s' is not an enum constructor" name

--- a/lib/typing/env.ml
+++ b/lib/typing/env.ml
@@ -2,20 +2,22 @@ open Base
 open Core_kernel
 open Scope
 
+type external_resolver = string -> name:string -> int option
+
 type t = {
   ctx: Type_context.t;
   file_scope: scope;
-  open_domains: string array list;
+  external_resolver: external_resolver;
   mutable current_scope: scope;
   mutable errors: Type_error.t list;
   mutable scope_counter: int;
   mutable in_lambda: bool;
 }
 
-let create ?(open_domains=[]) ~file_scope ctx =
+let create ~external_resolver ~file_scope ctx =
   {
     ctx;
-    open_domains;
+    external_resolver;
     file_scope;
     current_scope = file_scope;
     errors = [];

--- a/lib/typing/env.ml
+++ b/lib/typing/env.ml
@@ -56,6 +56,8 @@ let with_new_scope env scope callback =
   env.current_scope <- prev_scope;
   result
 
+let external_resolver env = env.external_resolver
+
 let get_global_type_val env =
   let root_scope = Type_context.root_scope env.ctx in
   root_scope#find_type_symbol

--- a/lib/typing/env.ml
+++ b/lib/typing/env.ml
@@ -72,5 +72,3 @@ let ty_f32 = unwrap_global_type "f32"
 let ty_char = unwrap_global_type "char"
 
 let ty_boolean = unwrap_global_type "boolean"
-
-let ty_unit = unwrap_global_type "unit"

--- a/lib/typing/env.mli
+++ b/lib/typing/env.mli
@@ -2,7 +2,9 @@ open Scope
 
 type t
 
-val create: ?open_domains:(string array list) -> file_scope:scope -> Type_context.t -> t
+type external_resolver = string -> name:string -> int option
+
+val create: external_resolver:external_resolver -> file_scope:scope -> Type_context.t -> t
 
 val ctx : t -> Type_context.t
 

--- a/lib/typing/env.mli
+++ b/lib/typing/env.mli
@@ -26,6 +26,8 @@ val errors: t -> Type_error.t list
 
 val with_new_scope: t -> scope -> (t -> 'a) -> 'a
 
+val external_resolver: t -> external_resolver
+
 val ty_u32: t -> int
 
 val ty_i32: t -> int

--- a/lib/typing/env.mli
+++ b/lib/typing/env.mli
@@ -35,5 +35,3 @@ val ty_f32: t -> int
 val ty_char: t -> int
 
 val ty_boolean: t -> int
-
-val ty_unit: t -> int

--- a/lib/typing/type_context.ml
+++ b/lib/typing/type_context.ml
@@ -26,7 +26,6 @@ let make_default_type_sym ctx scope =
   let open Core_type in
   let open Core_type.TypeDef in
   let names = [|
-    ("unit", Primitive);
     ("u32", Primitive);
     ("i32", Primitive);
     ("u64", Primitive);
@@ -108,6 +107,9 @@ and print_type_value ctx ty_value =
   match ty_value with
   | Unknown -> "unknown"
   | Any -> "any"
+
+  | Unit -> "unit"
+
   | Ctor (var, []) -> (
     let var = deref_type ctx var in
     match deref_type ctx var with

--- a/lib/typing/type_error.ml
+++ b/lib/typing/type_error.ml
@@ -29,6 +29,8 @@ type t =
   | NotAllTheCasesReturnSameType of (TypeExpr.t * TypeExpr.t)
   | CapitalizedEnumMember of string
   | LowercaseTheImportName of string
+  | LowercaseTheFunctionName of string
+  | LowercaseTheMethod of (string * string * string) (* class/enum, class name, method name *)
   | NotAEnumConstructor of string
   | RestParamsMustAtLast
   | ParamDoesNotProvided of string

--- a/lib/typing/type_error.ml
+++ b/lib/typing/type_error.ml
@@ -27,7 +27,8 @@ type t =
   | CannotResolveTypeOfExpression
   | DeclareFunctionShouldSpecificExternal
   | NotAllTheCasesReturnSameType of (TypeExpr.t * TypeExpr.t)
-  | CapitalizedEnumMemeber of string
+  | CapitalizedEnumMember of string
+  | LowercaseTheImportName of string
   | NotAEnumConstructor of string
   | RestParamsMustAtLast
   | ParamDoesNotProvided of string

--- a/lib/typing/type_error.ml
+++ b/lib/typing/type_error.ml
@@ -12,6 +12,7 @@ type t =
   | CannotUsedAsKeyOfMap of TypeExpr.t
   | CannotApplyUnary of UnaryOp.t * TypeExpr.t
   | CannotAccessBeforeInit of string
+  | CannotFindNameForImport of string * string  (* local_name, find_name *)
   | MissingMethodForInterface of string * string  (* interface_name, method_name *)
   | InvalidAssign
   | OnlyAssignArrayIndexAlpha

--- a/lib/typing/typecheck.ml
+++ b/lib/typing/typecheck.ml
@@ -21,7 +21,7 @@ open Lichenscript_parsing
 module IntHash = Hashtbl.Make(Int)
 module T = Typedtree
 
-type import_checker = Ast.Declaration.import -> unit
+type import_checker = Ast.Import.t -> unit
 
 (*
  * Type check deeply, check every expressions

--- a/lib/typing/typecheck.ml
+++ b/lib/typing/typecheck.ml
@@ -75,9 +75,6 @@ let[@warning "-unused-value-declaration"]
 let[@warning "-unused-value-declaration"]
   ty_boolean = unwrap_global_type "boolean"
 
-let[@warning "-unused-value-declaration"]
-  ty_unit =unwrap_global_type "unit"
-
 let with_scope env scope cb =
   let prev = env.scope in
   env.scope <- scope;
@@ -198,8 +195,7 @@ and check_block env blk =
     )
 
     | _ -> (
-      let unit_type = ty_unit env in
-      Type_context.update_node_type env.ctx return_ty (TypeExpr.Ctor(Ref unit_type, []))
+      Type_context.update_node_type env.ctx return_ty (TypeExpr.Unit)
     )
   )
 
@@ -242,8 +238,7 @@ and check_statement env stmt =
   | Debugger -> ()
 
   | Return None -> (
-    let unit_ty = ty_unit env in
-    add_return_type env (TypeExpr.Ctor(Ref unit_ty, []), stmt.loc)
+    add_return_type env (TypeExpr.Unit, stmt.loc)
   )
 
   | Return (Some expr) -> (
@@ -303,8 +298,7 @@ and check_expression_if env if_spec =
      * if there is no alternative, this if expression is regarded as 'unit' type,
      *)
     | None -> (
-      let ty_unit = ty_unit env in
-      let result = TypeExpr.Ctor(Ref ty_unit, []) in
+      let result = TypeExpr.Unit in
       if not (Check_helper.type_assinable env.ctx result node.value) then (
         let err = Diagnosis.(make_error env.ctx if_loc (NotAssignable(result, node.value))) in
         raise (Diagnosis.Error err)
@@ -796,7 +790,7 @@ and check_expression env expr =
       )
 
       | Literal Ast.Literal.Unit -> (
-        if not (Check_helper.is_unit env.ctx expr_type) then (
+        if not (Check_helper.is_unit expr_type) then (
           let err = Diagnosis.(make_error env.ctx pat.loc (UnexpectedPatternType("unit", expr_type))) in
           raise (Diagnosis.Error err)
         )
@@ -929,8 +923,7 @@ and check_expression env expr =
 
     let ty =
       if List.is_empty match_clauses then (
-        let ty_unit = ty_unit env in
-        TypeExpr.Ctor(Ref ty_unit, [])
+        TypeExpr.Unit
       ) else (
         (* TODO: better way to check every clauses *)
         List.fold

--- a/lib/typing/typecheck.mli
+++ b/lib/typing/typecheck.mli
@@ -1,5 +1,5 @@
 open Lichenscript_parsing
 
-type import_checker = Ast.Declaration.import -> unit
+type import_checker = Ast.Import.t -> unit
 
 val typecheck_module: Type_context.t -> import_checker:import_checker -> verbose:bool -> Typedtree.program -> unit

--- a/lib/typing/typedtree.ml
+++ b/lib/typing/typedtree.ml
@@ -307,7 +307,7 @@ and Declaration : sig
     | Function_ of Function.t
     | Declare of declare
     | Enum of Enum.t
-    | Import of Ast.Declaration.import
+    | Import of Ast.Import.t
     [@@deriving show]
 
   type t =


### PR DESCRIPTION
Allow importing another lib as a namespace:

✅
```
import lib from "anotherLib";

function main () {
  lib.test();
}
```

The first char of the name of the namespace should be lowercase.
Because the compiler regards capitalized name as a Class or a Enum.

❌
```
import Lib from "anotherLib";

function main () {
  Lib.test();
}
```